### PR TITLE
Project make target refinements 

### DIFF
--- a/build/automation/lib/project.mk
+++ b/build/automation/lib/project.mk
@@ -94,11 +94,11 @@ project-branch-deploy: ### Check if development branch can be deployed automatic
 	[ $$(make project-branch-test) == true ] && echo true && exit 0
 	echo false
 
-project-branch-test: ### Check if development branch can be tested automatically - return: true|false
+project-branch-test: ### Check if development branch can be tested automatically - optional KEYWORDS=[keywords,comma,separated] - return: true|false
+	keywords=$(or $(KEYWORDS) || test,func-test,perf-test,sec-test)
 	[[ $(BUILD_BRANCH) =~ $(GIT_BRANCH_PATTERN_MAIN) ]] && echo true && exit 0
 	[[ $(BUILD_BRANCH) =~ $(GIT_BRANCH_PATTERN_PREFIX)/$(GIT_BRANCH_PATTERN_SUFFIX) ]] && \
-		[ $$(make project-message-contains KEYWORD=test,func-test,perf-test,sec-test) == true ] && \
-			echo true && exit 0
+	[ $$(make project-message-contains KEYWORD=$$keywords) == true ] && echo true && exit 0
 	echo false
 
 project-branch-func-test: ### Check if development branch can be tested (functional) automatically - return: true|false

--- a/build/automation/lib/project.mk
+++ b/build/automation/lib/project.mk
@@ -125,7 +125,7 @@ project-branch-sec-test: ### Check if development branch can be tested (security
 project-message-contains: ### Check if git commit message contains any give keyword - mandatory KEYWORD=[comma-separated keywords]
 	msg=$$(make git-msg)
 	for str in $$(echo $(KEYWORD) | sed "s/,/ /g"); do
-		echo "$$msg" | grep -E '[ci .*]' | grep -Eoq "\[ci .*$${str}[^-].*" && echo true && exit 0
+		echo "$$msg" | grep -E '[ci .*]' | grep -Eoq "\[ci.*[^-]$${str}[^-].*" && echo true && exit 0
 	done
 	echo false
 


### PR DESCRIPTION
Some refinement around the pipeline targets used for CI deployment based of the git commit message, which was a result of work done for CI testing in Profile Updater.

- A change to the `project-branch-test` make target adds the ability to specifiy your own keywords to match on. This so a project can have it's own test keyword e.g. `smok-test`.

-  A refinement of the regex in the `project-message-contains` target, so it does not falsely return true for the `test` keyword when a sub test with a hypen in it has been specified e.g. `func-test`.