### PR TITLE
Add terraform and docker block rules to find aws account ids

### DIFF
--- a/build/automation/etc/git-secrets/nhsd-rules-banned.regexp
+++ b/build/automation/etc/git-secrets/nhsd-rules-banned.regexp
@@ -3,6 +3,8 @@
 [a-z]{2}-[a-z-]*-[1,2,3]\.rds\.amazonaws\.com
 rds\.[a-z]{2}-[a-z-]*-[1,2,3]\.amazonaws\.com
 dynamodb\.[a-z]{2}-[a-z-]*-[1,2,3]\.amazonaws\.com
+arn:aws:.*:.*:[0-9]{12}
+[0-9]{12}\.dkr\.ecr\.[a-z-]*-[1,2,3]\.amazonaws\.com
 [a-z]{2}-[a-z-]*-[1,2,3]\.es\.amazonaws\.com
 [a-z]*[1-3]\.cache\.amazonaws\.com
 hooks\.slack\.com/services/T[a-zA-Z0-9]*/B[a-zA-Z0-9]*/[a-zA-Z0-9]*


### PR DESCRIPTION
Add a couple of rules to the block list to catch account ids in docker.effective and terraform files